### PR TITLE
Bootstrap script more macOS friendly

### DIFF
--- a/00_bootstrap.sh
+++ b/00_bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo \#\# First prepare build environment
-wget http://shyboy.oss-cn-shenzhen.aliyuncs.com/readonly/tc32_gcc_v2.0.tar.bz2 -O docker/tc32_gcc.tar.bz2
+curl  http://shyboy.oss-cn-shenzhen.aliyuncs.com/readonly/tc32_gcc_v2.0.tar.bz2 > docker/tc32_gcc.tar.bz2
 docker build ./docker/ -t tc32
 
 
@@ -11,5 +11,4 @@ git clone --depth=1 https://github.com/Ai-Thinker-Open/Telink_825X_SDK SDK
 
 echo \#\# Download ATC_MiThermometer and patch makefile
 git clone https://github.com/atc1441/ATC_MiThermometer
-sed -i "/TEL_PATH := ..\/../c TEL_PATH := ..\/../SDK\/" ATC_MiThermometer/ATC_Thermometer/makefile
-
+sed -i '' 's#TEL_PATH := ..\/..#TEL_PATH := ..\/../SDK\/#g' ATC_MiThermometer/ATC_Thermometer/makefile

--- a/00_bootstrap.sh
+++ b/00_bootstrap.sh
@@ -11,4 +11,9 @@ git clone --depth=1 https://github.com/Ai-Thinker-Open/Telink_825X_SDK SDK
 
 echo \#\# Download ATC_MiThermometer and patch makefile
 git clone https://github.com/atc1441/ATC_MiThermometer
-sed -i '' 's#TEL_PATH := ..\/..#TEL_PATH := ..\/../SDK\/#g' ATC_MiThermometer/ATC_Thermometer/makefile
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's#TEL_PATH := ..\/..#TEL_PATH := ..\/../SDK\/#g' ATC_MiThermometer/ATC_Thermometer/makefile
+else
+    sed -i "/TEL_PATH := ..\/../c TEL_PATH := ..\/../SDK\/" ATC_MiThermometer/ATC_Thermometer/makefile
+fi


### PR DESCRIPTION
Just small change to make it work on mac and hopefully keep compatibility 
Default version of `sed` on macOS needs slightly different command to do the substitution + I replaced `wget` with `curl` which I believe can safely cover Linux and macOS platforms (wget is not available by default on mac)

Big thanks for making the TC32 Docker builder!