### PR TITLE
Use alternative method for setting the TEL_PATH at make

### DIFF
--- a/00_bootstrap.sh
+++ b/00_bootstrap.sh
@@ -9,11 +9,5 @@ echo \#\# Now download Telink 825X SDK
 git clone --depth=1 https://github.com/Ai-Thinker-Open/Telink_825X_SDK SDK
 
 
-echo \#\# Download ATC_MiThermometer and patch makefile
+echo \#\# Download ATC_MiThermometer project
 git clone https://github.com/atc1441/ATC_MiThermometer
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' 's#TEL_PATH := ..\/..#TEL_PATH := ..\/../SDK\/#g' ATC_MiThermometer/ATC_Thermometer/makefile
-else
-    sed -i "/TEL_PATH := ..\/../c TEL_PATH := ..\/../SDK\/" ATC_MiThermometer/ATC_Thermometer/makefile
-fi

--- a/01_make.sh
+++ b/01_make.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -v $PWD:/app -it tc32 -c "cd ATC_MiThermometer/ATC_Thermometer && make $@"
+docker run --rm -v $PWD:/app -it tc32 -c "cd ATC_MiThermometer/ATC_Thermometer && TEL_PATH=../../SDK make $@"


### PR DESCRIPTION
This approach bypasses the need of altering the makefile of the thermometer project on docker build.

Do not merge this before this PR got merged:
https://github.com/atc1441/ATC_MiThermometer/pull/91

Fixes #3 